### PR TITLE
Feature/#3 core module setting

### DIFF
--- a/core/common/src/main/java/com/jinukeu/core/common/MyClass.kt
+++ b/core/common/src/main/java/com/jinukeu/core/common/MyClass.kt
@@ -1,3 +1,0 @@
-package com.jinukeu.core.common
-
-class MyClass

--- a/core/common/src/main/java/com/jinukeu/core/common/RunCatchingIgnoreCancelled.kt
+++ b/core/common/src/main/java/com/jinukeu/core/common/RunCatchingIgnoreCancelled.kt
@@ -1,0 +1,8 @@
+package com.jinukeu.core.common
+
+import kotlin.coroutines.cancellation.CancellationException
+
+inline fun <T> runCatchingIgnoreCancelled(block: () -> T): Result<T> = runCatching(block)
+  .onFailure { error ->
+    if (error is CancellationException) throw error
+  }

--- a/core/model/src/main/java/com/jinukeu/core/model/CommonExceptions.kt
+++ b/core/model/src/main/java/com/jinukeu/core/model/CommonExceptions.kt
@@ -1,0 +1,21 @@
+package com.jinukeu.core.model
+
+class RequestFailException(
+  override val message: String = "요청을 처리하지 못했어요.",
+) : RuntimeException()
+
+class ForbiddenException(
+  override val message: String = "제한된 요청이에요.",
+) : RuntimeException()
+
+class NotFoundException(
+  override val message: String = "정보를 찾을 수 없어요.",
+) : RuntimeException()
+
+class NetworkException(
+  override val message: String = "네트워크 연결 상태 또는 서버에 문제가 있어요.",
+) : RuntimeException()
+
+class UnknownException(
+  override val message: String = "알 수 없는 에러가 발생했어요.",
+) : RuntimeException()

--- a/core/model/src/main/java/com/jinukeu/core/model/MyClass.kt
+++ b/core/model/src/main/java/com/jinukeu/core/model/MyClass.kt
@@ -1,3 +1,0 @@
-package com.jinukeu.core.model
-
-class MyClass

--- a/core/network/src/main/java/com/jinukeu/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/jinukeu/core/network/di/NetworkModule.kt
@@ -1,0 +1,88 @@
+package com.jinukeu.core.network.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.jinukeu.core.network.BuildConfig
+import com.jinukeu.core.network.retrofit.ResultCallAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+  private const val RETROFIT_TAG = "Retrofit2"
+
+  @Singleton
+  @Provides
+  fun provideOkHttpClient(
+    loggingInterceptor: HttpLoggingInterceptor,
+  ): OkHttpClient {
+    return OkHttpClient.Builder()
+      .readTimeout(10, TimeUnit.SECONDS)
+      .connectTimeout(10, TimeUnit.SECONDS)
+      .writeTimeout(15, TimeUnit.SECONDS)
+      .addInterceptor(loggingInterceptor)
+      .build()
+  }
+
+  @Singleton
+  @Provides
+  fun provideJson(): Json {
+    return Json {
+      prettyPrint = true
+      coerceInputValues = true
+      ignoreUnknownKeys = true
+    }
+  }
+
+  @Singleton
+  @Provides
+  fun provideLoggingInterceptor(
+    json: Json,
+  ): HttpLoggingInterceptor {
+    val loggingInterceptor = HttpLoggingInterceptor { message ->
+      when {
+        !message.isJsonObject() && !message.isJsonArray() ->
+          Timber.tag(RETROFIT_TAG).d("CONNECTION INFO -> $message")
+
+        else -> kotlin.runCatching {
+          json.encodeToString(Json.parseToJsonElement(message))
+        }.onSuccess {
+          Timber.tag(RETROFIT_TAG).d(it)
+        }.onFailure {
+          Timber.tag(RETROFIT_TAG).d(message)
+        }
+      }
+    }
+    loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+    return loggingInterceptor
+  }
+
+  @Singleton
+  @Provides
+  fun provideRetrofit(
+    okHttpClient: OkHttpClient,
+    json: Json,
+  ): Retrofit {
+    return Retrofit.Builder()
+      .baseUrl(BuildConfig.BASE_URL)
+      .client(okHttpClient)
+      .addCallAdapterFactory(ResultCallAdapterFactory())
+      .addConverterFactory(json.asConverterFactory("application/json".toMediaTypeOrNull()!!))
+      .build()
+  }
+}
+
+private fun String?.isJsonObject(): Boolean = this?.startsWith("{") == true && this.endsWith("}")
+private fun String?.isJsonArray(): Boolean = this?.startsWith("[") == true && this.endsWith("]")

--- a/core/network/src/main/java/com/jinukeu/core/network/retrofit/ApiResult.kt
+++ b/core/network/src/main/java/com/jinukeu/core/network/retrofit/ApiResult.kt
@@ -1,0 +1,88 @@
+package com.jinukeu.core.network.retrofit
+
+import com.jinukeu.core.model.ForbiddenException
+import com.jinukeu.core.model.NetworkException
+import com.jinukeu.core.model.NotFoundException
+import com.jinukeu.core.model.RequestFailException
+import com.jinukeu.core.model.UnknownException
+
+sealed interface ApiResult<out T> {
+  data class Success<T>(val data: T) : ApiResult<T>
+
+  sealed interface Failure : ApiResult<Nothing> {
+    data class HttpError(val code: Int, val message: String, val body: String) : Failure
+    data class NetworkError(val throwable: Throwable) : Failure
+    data class UnknownApiError(val throwable: Throwable) : Failure
+
+    fun safeThrowable(): Throwable =
+      when (this) {
+        is HttpError -> handleHttpError(code)
+        is NetworkError -> throwable
+        is UnknownApiError -> throwable
+      }
+  }
+
+  val isSuccess: Boolean
+    get() = this is Success
+
+  val isFailure: Boolean
+    get() = this is Failure
+
+  fun getOrThrow(): T {
+    throwFailure()
+    return (this as Success).data
+  }
+
+  fun getOrNull(): T? =
+    when (this) {
+      is Success -> data
+      else -> null
+    }
+
+  fun failureOrThrow(): Failure {
+    throwOnSuccess()
+    return this as Failure
+  }
+
+  fun exceptionOrNull(): Throwable? =
+    when (this) {
+      is Failure -> safeThrowable()
+      else -> null
+    }
+
+  companion object {
+    fun <R> successOf(result: R): ApiResult<R> = Success(result)
+  }
+}
+
+inline fun <T> ApiResult<T>.onSuccess(
+  action: (value: T) -> Unit,
+): ApiResult<T> {
+  if (isSuccess) action(getOrThrow())
+  return this
+}
+
+inline fun <T> ApiResult<T>.onFailure(
+  action: (error: ApiResult.Failure) -> Unit,
+): ApiResult<T> {
+  if (isFailure) action(failureOrThrow())
+  return this
+}
+
+internal fun ApiResult<*>.throwOnSuccess() {
+  if (this is ApiResult.Success) throw IllegalStateException("Cannot be called under Success conditions.")
+}
+
+internal fun ApiResult<*>.throwFailure() {
+  if (this is ApiResult.Failure) {
+    throw safeThrowable()
+  }
+}
+
+private fun handleHttpError(httpStatusCode: Int): Exception = when (httpStatusCode) {
+  400 -> RequestFailException()
+  403 -> ForbiddenException()
+  404 -> NotFoundException()
+  500, 501, 502, 503, 504, 505 -> NetworkException()
+  else -> UnknownException()
+}

--- a/core/network/src/main/java/com/jinukeu/core/network/retrofit/ApiResultCallAdapter.kt
+++ b/core/network/src/main/java/com/jinukeu/core/network/retrofit/ApiResultCallAdapter.kt
@@ -1,0 +1,79 @@
+package com.jinukeu.core.network.retrofit
+
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.IOException
+import java.lang.reflect.Type
+
+internal class ApiResultCallAdapter<R>(
+  private val successType: Type,
+) : CallAdapter<R, Call<ApiResult<R>>> {
+  override fun adapt(call: Call<R>): Call<ApiResult<R>> = ApiResultCall(call, successType)
+  override fun responseType(): Type = successType
+}
+
+private class ApiResultCall<R>(
+  private val delegate: Call<R>,
+  private val successType: Type,
+) : Call<ApiResult<R>> {
+
+  override fun enqueue(callback: Callback<ApiResult<R>>) = delegate.enqueue(
+    object : Callback<R> {
+      override fun onResponse(call: Call<R>, response: Response<R>) {
+        callback.onResponse(this@ApiResultCall, Response.success(response.toApiResult()))
+      }
+
+      private fun Response<R>.toApiResult(): ApiResult<R> {
+        if (!isSuccessful) { // Http 응답 에러
+          val errorBody = errorBody()?.string()
+          return ApiResult.Failure.HttpError(
+            code = code(),
+            message = message(),
+            body = errorBody ?: "Unknown http response error",
+          )
+        }
+
+        body()?.let { body -> return ApiResult.successOf(body) }
+
+        return if (successType == Unit::class.java) {
+          @Suppress("UNCHECKED_CAST")
+          ApiResult.successOf(Unit as R)
+        } else {
+          ApiResult.Failure.UnknownApiError(
+            IllegalStateException(
+              "Body가 존재하지 않지만, Unit 이외의 타입으로 정의했습니다. ApiResult<Unit>로 정의하세요.",
+            ),
+          )
+        }
+      }
+
+      override fun onFailure(call: Call<R>, throwable: Throwable) {
+        val error = if (throwable is IOException) {
+          ApiResult.Failure.NetworkError(throwable)
+        } else {
+          ApiResult.Failure.UnknownApiError(throwable)
+        }
+        callback.onResponse(this@ApiResultCall, Response.success(error))
+      }
+    },
+  )
+
+  override fun clone(): Call<ApiResult<R>> = ApiResultCall(delegate.clone(), successType)
+
+  override fun execute(): Response<ApiResult<R>> =
+    throw UnsupportedOperationException("This adapter doesn't support sync execution")
+
+  override fun isExecuted(): Boolean = delegate.isExecuted
+
+  override fun cancel() = delegate.cancel()
+
+  override fun isCanceled(): Boolean = delegate.isCanceled
+
+  override fun request(): Request = delegate.request()
+
+  override fun timeout(): Timeout = delegate.timeout()
+}

--- a/core/network/src/main/java/com/jinukeu/core/network/retrofit/ResultCallAdapterFactory.kt
+++ b/core/network/src/main/java/com/jinukeu/core/network/retrofit/ResultCallAdapterFactory.kt
@@ -1,0 +1,55 @@
+package com.jinukeu.core.network.retrofit
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+class ResultCallAdapterFactory : CallAdapter.Factory() {
+  override fun get(
+    returnType: Type,
+    annotations: Array<out Annotation>,
+    retrofit: Retrofit,
+  ): CallAdapter<*, *>? {
+    val rawType = getRawType(returnType)
+
+    if (returnType !is ParameterizedType) {
+      val name = parseTypeName(returnType)
+      throw IllegalArgumentException("Return 타입은 $name<Foo> 또는 $name<out Foo>로 정의되어야 합니다.")
+    }
+
+    return when (rawType) {
+      Call::class.java -> apiResultAdapter(returnType)
+      else -> null
+    }
+  }
+
+  private fun apiResultAdapter(
+    returnType: ParameterizedType,
+  ): CallAdapter<Type, out Call<out Any>>? {
+    val wrapperType = getParameterUpperBound(0, returnType)
+    return when (getRawType(wrapperType)) {
+      ApiResult::class.java -> {
+        val bodyType = extractReturnType(wrapperType, returnType)
+        ApiResultCallAdapter(bodyType)
+      }
+
+      else -> null
+    }
+  }
+
+  private fun extractReturnType(
+    wrapperType: Type,
+    returnType: ParameterizedType,
+  ): Type {
+    if (wrapperType !is ParameterizedType) {
+      val name = parseTypeName(returnType)
+      throw IllegalArgumentException(
+        "Return 타입은 $name<ResponseBody>로 정의되어야 합니다.",
+      )
+    }
+    return getParameterUpperBound(0, wrapperType)
+  }
+}
+
+private fun parseTypeName(type: Type) = type.toString().split('.').last()

--- a/core/ui/src/main/java/com/jinukeu/core/ui/base/BaseViewModel.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/base/BaseViewModel.kt
@@ -1,0 +1,35 @@
+package com.jinukeu.core.ui.base
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+abstract class BaseViewModel<UI_STATE : UiState, SIDE_EFFECT : SideEffect>(
+  initialState: UI_STATE,
+) : ViewModel() {
+
+  private val _uiState = MutableStateFlow(initialState)
+  val uiState = _uiState.asStateFlow()
+
+  private val _sideEffect: Channel<SIDE_EFFECT> = Channel()
+  val sideEffect = _sideEffect.receiveAsFlow()
+
+  protected val currentState: UI_STATE
+    get() = _uiState.value
+
+  protected fun intent(reduce: UI_STATE.() -> UI_STATE) {
+    val state = currentState.reduce()
+    _uiState.update { state }
+  }
+
+  protected fun postSideEffect(vararg builder: SIDE_EFFECT) {
+    for (effectValue in builder) {
+      viewModelScope.launch { _sideEffect.send(effectValue) }
+    }
+  }
+}

--- a/core/ui/src/main/java/com/jinukeu/core/ui/base/SideEffect.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/base/SideEffect.kt
@@ -1,0 +1,3 @@
+package com.jinukeu.core.ui.base
+
+interface SideEffect

--- a/core/ui/src/main/java/com/jinukeu/core/ui/base/UiState.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/base/UiState.kt
@@ -1,0 +1,3 @@
+package com.jinukeu.core.ui.base
+
+interface UiState

--- a/core/ui/src/main/java/com/jinukeu/core/ui/extension/Flow.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/extension/Flow.kt
@@ -1,0 +1,23 @@
+package com.jinukeu.core.ui.extension
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+
+@Composable
+inline fun <reified T> Flow<T>.collectWithLifecycle(
+  minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+  noinline action: suspend (T) -> Unit,
+) {
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  LaunchedEffect(this, lifecycleOwner) {
+    lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
+      this@collectWithLifecycle.collect { action(it) }
+    }
+  }
+}

--- a/core/ui/src/main/java/com/jinukeu/core/ui/extension/Generic.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/extension/Generic.kt
@@ -1,0 +1,7 @@
+package com.jinukeu.core.ui.extension
+
+inline fun <T> T.runIf(condition: Boolean, run: T.() -> T) = if (condition) {
+  run()
+} else {
+  this
+}

--- a/core/ui/src/main/java/com/jinukeu/core/ui/extension/LazyListState.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/extension/LazyListState.kt
@@ -1,0 +1,40 @@
+package com.jinukeu.core.ui.extension
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+
+// https://manavtamboli.medium.com/infinite-list-paged-list-in-jetpack-compose-b10fc7e74768
+@Composable
+fun LazyListState.OnBottomReached(
+  // tells how many items before we reach the bottom of the list
+  // to call onLoadMore function
+  buffer: Int = 0,
+  onLoadMore: () -> Unit,
+) {
+  // Buffer must be positive.
+  // Or our list will never reach the bottom.
+  require(buffer >= 0) { "buffer cannot be negative, but was $buffer" }
+
+  val shouldLoadMore = remember {
+    derivedStateOf {
+      val lastVisibleItem = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf true
+
+      lastVisibleItem.index >= layoutInfo.totalItemsCount - 1 - buffer
+    }
+  }
+
+  LaunchedEffect(shouldLoadMore) {
+    snapshotFlow { shouldLoadMore.value }
+      .collect {
+        if (it) {
+          onLoadMore()
+        }
+      }
+  }
+}
+
+fun LazyListState.isScrolledToEnd() = layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1

--- a/core/ui/src/main/java/com/jinukeu/core/ui/extension/Modifier.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/extension/Modifier.kt
@@ -1,0 +1,59 @@
+package com.jinukeu.core.ui.extension
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import com.jinukeu.core.ui.util.MultipleEventsCutter
+import com.jinukeu.core.ui.util.get
+
+/**
+ * Composable 에 clickable 을 설정해주는 [Modifier]
+ *
+ * @param rippleEnabled Ripple 여부 설정
+ * @param rippleColor 표시된 Ripple Color
+ * @param runIf clickable 이 발생하는 조건
+ * @param singleClick 더블 클릭 방지 여부
+ * @param onClick 컴포넌트가 클릭됐을 때 실행할 람다식
+ *
+ * @return clickable 이 적용된 [Modifier]
+ */
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.itbookClickable(
+  rippleEnabled: Boolean = true,
+  rippleColor: Color? = null,
+  runIf: Boolean = true,
+  singleClick: Boolean = true,
+  onLongClick: (() -> Unit)? = null,
+  onClick: (() -> Unit)?,
+) = runIf(runIf) {
+  composed {
+    val multipleEventsCutter = remember { MultipleEventsCutter.get() }
+
+    combinedClickable(
+      onClick = {
+        onClick?.let {
+          if (singleClick) {
+            multipleEventsCutter.processEvent {
+              it()
+            }
+          } else {
+            it()
+          }
+        }
+      },
+      onLongClick = onLongClick,
+      indication = ripple(
+        color = rippleColor ?: Color.Unspecified,
+      ).takeIf {
+        rippleEnabled
+      },
+      interactionSource = remember { MutableInteractionSource() },
+    )
+  }
+}

--- a/core/ui/src/main/java/com/jinukeu/core/ui/util/MultipleEventsCutter.kt
+++ b/core/ui/src/main/java/com/jinukeu/core/ui/util/MultipleEventsCutter.kt
@@ -1,0 +1,29 @@
+package com.jinukeu.core.ui.util
+
+/**
+ * 클릭이 지연될 시간을 정의하는 변수
+ */
+private const val CLICK_EVENT_DELAY_TIME: Long = 300L
+
+internal interface MultipleEventsCutter {
+  fun processEvent(event: () -> Unit)
+
+  companion object
+}
+
+internal fun MultipleEventsCutter.Companion.get(): MultipleEventsCutter =
+  MultipleEventsCutterImpl()
+
+private class MultipleEventsCutterImpl : MultipleEventsCutter {
+  private val now: Long
+    get() = System.currentTimeMillis()
+
+  private var lastEventTimeMs: Long = 0
+
+  override fun processEvent(event: () -> Unit) {
+    if (now - lastEventTimeMs >= CLICK_EVENT_DELAY_TIME) {
+      event.invoke()
+    }
+    lastEventTimeMs = now
+  }
+}


### PR DESCRIPTION
## 💡 Issue
- Resolved: #3

## 🌱 Key changes
<!--변경사항 적기-->
 - BaseViewModel과 runCatchingIgnoreCancelled + 기타 확장함수 추가
- 기본적인 Retrofit2 세팅을 합니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
retrofit2 custom callAdapterFactory를 사용하여 에러 처리를 합니다.
[참고 자료](https://pluu.github.io/blog/android/2023/04/29/custom-calladapter-factory/)

아래는 본문의 내용 중 일부입니다.

```
1. (난이도 하) API 요청하는 곳에서 try/catch 처리
2. (난이도 하) CoroutineExceptionHandler의 Throwable로 if/else 처리
3. (난이도 중/상) Retrofit의 CallAdapterFactory로 일괄 처리

1/2번 방법은 필요한 곳마다 사용하게 되면 유사한 코드가 여러 곳에 존재하게 되는 보일러플레이트 코드가 생산됩니다. 난이도는 좀 더 높지만, 한 번만 작성면 중복코드를 최소화할 수 있는 3번 방법을 소개하겠습니다.
```
---

#### BaseViewModel
BaseViewModel 코드는 아래와 같으며 `core:ui` 모듈에 추가하겠습니다.
```kotlin
abstract class BaseViewModel<UI_STATE : UiState, SIDE_EFFECT : SideEffect>(
    initialState: UI_STATE,
) : ViewModel() {

    private val _uiState = MutableStateFlow(initialState)
    val uiState = _uiState.asStateFlow()

    private val _sideEffect: Channel<SIDE_EFFECT> = Channel()
    val sideEffect = _sideEffect.receiveAsFlow()

    protected val currentState: UI_STATE
        get() = _uiState.value

    protected fun intent(reduce: UI_STATE.() -> UI_STATE) {
        val state = currentState.reduce()
        _uiState.update { state }
    }

    protected fun postSideEffect(vararg builder: SIDE_EFFECT) {
        for (effectValue in builder) {
            viewModelScope.launch { _sideEffect.send(effectValue) }
        }
    }
}
```

---
### runCatchingIgnoreCancelled
runCatchingIgnoreCancelled는 아래와 같으며 모든 모듈에서 사용가능하므로 `core:common` 모듈에 추가하겠습니다.
```kotlin
inline fun <T> runCatchingIgnoreCancelled(block: () -> T): Result<T> = runCatching(block)
  .onFailure { error ->
    if (error is CancellationException) throw error
  }


```

runCatchingIgnoreCancelled는 기존 runCatching이 CancellationException을 catch하는 문제점을 해결한 방법입니다.
자세한 내용은 아래 두 자료를 참고해주세요.
[멀티 모듈 에러 핸들링.pdf](https://github.com/YAPP-Github/oksusu-susu-android/files/13499810/default.pdf)
[참고 링크](https://slack-chats.kotlinlang.org/t/10065472/hey-i-want-to-ask-people-around-if-runcatching-is-in-use-in-#496baf73-c13a-4f0e-8668-1d2268587a9e)

---

### 기타 확장 함수
Compose에서 안드로이드 라이프사이클을 인식하는 `collectWithLifecycle` 추가하겠습니다.
```kotlin
@Composable
inline fun <reified T> Flow<T>.collectWithLifecycle(
    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
    noinline action: suspend (T) -> Unit,
) {
    val lifecycleOwner = LocalLifecycleOwner.current

    LaunchedEffect(this, lifecycleOwner) {
        lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
            this@collectWithLifecycle.collect { action(it) }
        }
    }
}
```

커스텀 clickable Modifier 확장 함수 추가하겠습니다.
```kotlin
/**
 * Composable 에 clickable 을 설정해주는 [Modifier]
 *
 * @param rippleEnabled Ripple 여부 설정
 * @param rippleColor 표시된 Ripple Color
 * @param runIf clickable 이 발생하는 조건
 * @param singleClick 더블 클릭 방지 여부
 * @param onClick 컴포넌트가 클릭됐을 때 실행할 람다식
 *
 * @return clickable 이 적용된 [Modifier]
 */
@OptIn(ExperimentalFoundationApi::class)
fun Modifier.susuClickable(
    rippleEnabled: Boolean = true,
    rippleColor: Color? = null,
    runIf: Boolean = true,
    singleClick: Boolean = true,
    onLongClick: (() -> Unit)? = null,
    onClick: (() -> Unit)?,
) = runIf(runIf) {
    composed {
        val multipleEventsCutter = remember { MultipleEventsCutter.get() }

        combinedClickable(
            onClick = {
                onClick?.let {
                    if (singleClick) {
                        multipleEventsCutter.processEvent {
                            it()
                        }
                    } else {
                        it()
                    }
                }
            },
            onLongClick = onLongClick,
            indication = rememberRipple(
                color = rippleColor ?: Color.Unspecified,
            ).takeIf {
                rippleEnabled
            },
            interactionSource = remember { MutableInteractionSource() },
        )
    }
}
```

## 📸 스크린샷

